### PR TITLE
Implement Sieve of Eratosthenes in Rust with CLI and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,33 @@ name: CI
 on:
   push:
     branches:
-      - "**"
+      - '**'
   pull_request:
     branches:
-      - "**"
+      - '**'
 
 jobs:
   test:
+    name: Run tests
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Run tests
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run cargo test
         run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,7 @@
 name = "eratosthenes"
 version = "0.1.0"
 edition = "2021"
+
+[[bin]]
+name = "eratosthenes"
+path = "src/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "eratosthenes"
+version = "0.1.0"
+edition = "2021"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,31 @@
 use std::env;
-use std::process;
 
 fn first_n_primes(n: usize) -> Vec<u64> {
     if n == 0 {
         return vec![];
     }
 
-    // Determine an upper bound for the sieve using the prime-counting upper bound.
-    // For n >= 6: upper bound ~ n * (ln(n) + ln(ln(n)))
-    // For n < 6: use a hardcoded ceiling of 100
-    let upper_bound: usize = if n < 6 {
+    // Determine upper bound using prime number theorem approximation
+    let limit: usize = if n < 6 {
         100
     } else {
         let n_f = n as f64;
-        let ln_n = n_f.ln();
-        let ln_ln_n = ln_n.ln();
-        (n_f * (ln_n + ln_ln_n)).ceil() as usize + 10
+        let upper = n_f * (n_f.ln() + n_f.ln().ln());
+        upper.ceil() as usize + 1
     };
 
     // Sieve of Eratosthenes
-    let mut is_prime = vec![true; upper_bound + 1];
+    let mut is_prime = vec![true; limit + 1];
     is_prime[0] = false;
-    if upper_bound >= 1 {
+    if limit >= 1 {
         is_prime[1] = false;
     }
 
     let mut i = 2;
-    while i * i <= upper_bound {
+    while i * i <= limit {
         if is_prime[i] {
             let mut j = i * i;
-            while j <= upper_bound {
+            while j <= limit {
                 is_prime[j] = false;
                 j += i;
             }
@@ -51,23 +47,18 @@ fn first_n_primes(n: usize) -> Vec<u64> {
 fn main() {
     let args: Vec<String> = env::args().collect();
 
-    if args.len() != 2 {
+    if args.len() < 2 {
         eprintln!("Usage: {} <N>", args[0]);
-        eprintln!("  N  a positive integer — prints the first N prime numbers");
-        process::exit(1);
+        eprintln!("  Prints the first N prime numbers, one per line.");
+        std::process::exit(1);
     }
 
-    let n: usize = match args[1].parse::<usize>() {
-        Ok(v) if v > 0 => v,
-        Ok(_) => {
-            eprintln!("Error: N must be a positive integer, got '{}'", args[1]);
-            eprintln!("Usage: {} <N>", args[0]);
-            process::exit(1);
-        }
+    let n: usize = match args[1].parse() {
+        Ok(val) => val,
         Err(_) => {
-            eprintln!("Error: '{}' is not a valid positive integer", args[1]);
+            eprintln!("Error: '{}' is not a valid non-negative integer.", args[1]);
             eprintln!("Usage: {} <N>", args[0]);
-            process::exit(1);
+            std::process::exit(1);
         }
     };
 
@@ -99,9 +90,9 @@ mod tests {
     }
 
     #[test]
-    fn test_hundredth_prime() {
+    fn test_first_hundred_primes_last_element() {
         let primes = first_n_primes(100);
         assert_eq!(primes.len(), 100);
-        assert_eq!(primes[99], 541);
+        assert_eq!(*primes.last().unwrap(), 541);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,107 @@
+use std::env;
+use std::process;
+
+fn first_n_primes(n: usize) -> Vec<u64> {
+    if n == 0 {
+        return vec![];
+    }
+
+    // Determine an upper bound for the sieve using the prime-counting upper bound.
+    // For n >= 6: upper bound ~ n * (ln(n) + ln(ln(n)))
+    // For n < 6: use a hardcoded ceiling of 100
+    let upper_bound: usize = if n < 6 {
+        100
+    } else {
+        let n_f = n as f64;
+        let ln_n = n_f.ln();
+        let ln_ln_n = ln_n.ln();
+        (n_f * (ln_n + ln_ln_n)).ceil() as usize + 10
+    };
+
+    // Sieve of Eratosthenes
+    let mut is_prime = vec![true; upper_bound + 1];
+    is_prime[0] = false;
+    if upper_bound >= 1 {
+        is_prime[1] = false;
+    }
+
+    let mut i = 2;
+    while i * i <= upper_bound {
+        if is_prime[i] {
+            let mut j = i * i;
+            while j <= upper_bound {
+                is_prime[j] = false;
+                j += i;
+            }
+        }
+        i += 1;
+    }
+
+    let primes: Vec<u64> = is_prime
+        .iter()
+        .enumerate()
+        .filter(|(_, &p)| p)
+        .map(|(i, _)| i as u64)
+        .take(n)
+        .collect();
+
+    primes
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        eprintln!("Usage: {} <N>", args[0]);
+        eprintln!("  N  a positive integer — prints the first N prime numbers");
+        process::exit(1);
+    }
+
+    let n: usize = match args[1].parse::<usize>() {
+        Ok(v) if v > 0 => v,
+        Ok(_) => {
+            eprintln!("Error: N must be a positive integer, got '{}'", args[1]);
+            eprintln!("Usage: {} <N>", args[0]);
+            process::exit(1);
+        }
+        Err(_) => {
+            eprintln!("Error: '{}' is not a valid positive integer", args[1]);
+            eprintln!("Usage: {} <N>", args[0]);
+            process::exit(1);
+        }
+    };
+
+    for prime in first_n_primes(n) {
+        println!("{}", prime);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero_primes() {
+        assert_eq!(first_n_primes(0), vec![]);
+    }
+
+    #[test]
+    fn test_first_prime() {
+        assert_eq!(first_n_primes(1), vec![2]);
+    }
+
+    #[test]
+    fn test_first_ten_primes() {
+        assert_eq!(
+            first_n_primes(10),
+            vec![2, 3, 5, 7, 11, 13, 17, 19, 23, 29]
+        );
+    }
+
+    #[test]
+    fn test_hundredth_prime() {
+        let primes = first_n_primes(100);
+        assert_eq!(primes.len(), 100);
+        assert_eq!(primes[99], 541);
+    }
+}


### PR DESCRIPTION
Closes #1

## Summary

- Adds `Cargo.toml` to initialise a standard `cargo` binary project named `eratosthenes`.
- Implements `fn first_n_primes(n: usize) -> Vec<u64>` in `src/main.rs` using the Sieve of Eratosthenes. The sieve upper bound is computed from the prime-counting approximation `n * (ln(n) + ln(ln(n)))` for `n >= 6`, with a hardcoded ceiling of 100 for smaller values.
- The `main` function parses `N` from `argv[1]`, emits a usage message and exits non-zero on missing or invalid input, and prints one prime per line to stdout.
- A `#[cfg(test)]` module covers the four required cases: empty result for `n=0`, `[2]` for `n=1`, the first ten primes for `n=10`, and the 100th prime (`541`) for `n=100`.
- Adds `.github/workflows/ci.yml` that triggers on every push and pull request to any branch, checks out the code, installs the stable Rust toolchain via `dtolnay/rust-toolchain`, and runs `cargo test`.